### PR TITLE
Add /vendor to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor


### PR DESCRIPTION
This way `bundle install` does not generate untracked files in git