### PR TITLE
JRuby: Modifying travis config to make it work reliably with jruby 9.1.13 and jruby-head

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,16 @@ language: ruby
 rvm:
   - 2.4
   - ruby-head
-  - jruby
-  - jruby-head
 matrix:
+  include:
+    - rvm: jruby-9.1.13.0
+      jdk: openjdk8
+    - rvm: jruby-9.1.13.0
+      jdk: oraclejdk8
+    - rvm: jruby-head
+      jdk: openjdk8
+    - rvm: jruby-head
+      jdk: oraclejdk8
   allow_failures:
-  # Even `rvm use jruby` does not work reliably on Travis:
-  # https://travis-ci.org/ruby/ipaddr/jobs/277222999
-  - rvm: jruby
-  - rvm: jruby-head
+    - rvm: jruby-head
 before_install: gem install bundler


### PR DESCRIPTION
I've been testing some configurations/matrix on Travis in order to make it work reliably and at least looks OK on my own Travis:

https://travis-ci.org/esparta/ipaddr/builds

The only change is the specification of the JDK to work with.