### PR TITLE
Use caller with length to reduce unused strings

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -310,7 +310,7 @@ class IPAddr
 
   # Returns true if the ipaddr is an IPv4-compatible IPv6 address.
   def ipv4_compat?
-    warn "#{caller(1)[0]}: warning: IPAddr\##{__callee__} is obsolete" if $VERBOSE
+    warn "#{caller(1, 1)[0]}: warning: IPAddr\##{__callee__} is obsolete" if $VERBOSE
     _ipv4_compat?
   end
 
@@ -336,7 +336,7 @@ class IPAddr
   # Returns a new ipaddr built by converting the native IPv4 address
   # into an IPv4-compatible IPv6 address.
   def ipv4_compat
-    warn "#{caller(1)[0]}: warning: IPAddr\##{__callee__} is obsolete" if $VERBOSE
+    warn "#{caller(1, 1)[0]}: warning: IPAddr\##{__callee__} is obsolete" if $VERBOSE
     if !ipv4?
       raise InvalidAddressError, "not an IPv4 address"
     end


### PR DESCRIPTION
This PR is similar to #7, but actually cherry-picked https://github.com/ruby/ruby/commit/dabdec31e4f10a83036cfb368bf3a7d4d20cf2d8 from the ruby repo in order to preserve the commit author information and the commit message from the original commit.