### PR TITLE
Upgrade Bundler to 2.0 to fix Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 rvm:
   - 2.3
   - 2.4
-  - 2.5.0
+  - 2.5
+  - 2.6
   - ruby-head
 matrix:
   include:

--- a/ipaddr.gemspec
+++ b/ipaddr.gemspec
@@ -22,7 +22,7 @@ Both IPv4 and IPv6 are supported.
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.15"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
Because Travis is broken since Bundler 2.0 release so we either need to stick with Bundler 1.17.x or upgrade to 2.x. I chose to upgrade.