### PR TITLE
Add IPAddr#unmasked

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -374,6 +374,11 @@ class IPAddr
     return self.clone.set(@addr + 1, @family)
   end
 
+  # Returns a new ipaddr without a mask
+  def unmasked
+    self.class.new(@unmasked_addr, @family)
+  end
+
   # Compares the ipaddr with another.
   def <=>(other)
     other = coerce_other(other)
@@ -504,6 +509,7 @@ class IPAddr
       raise AddressFamilyError, "unsupported address family"
     end
     @addr = addr
+    @unmasked_addr = addr
     if family[0]
       @family = family[0]
     end
@@ -616,6 +622,7 @@ class IPAddr
     if family != Socket::AF_UNSPEC && @family != family
       raise AddressFamilyError, "address family mismatch"
     end
+    @unmasked_addr = @addr
     if prefixlen
       mask!(prefixlen)
     else

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -422,4 +422,13 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(true, s.include?(a5))
     assert_equal(true, s.include?(a6))
   end
+
+  def test_unmasked
+    assert_equal(IPAddr.new("1.2.3.4"), IPAddr.new("1.2.3.4").unmasked)
+    assert_equal(IPAddr.new("1.2.3.4"), IPAddr.new("1.2.3.4/8").unmasked)
+    assert_equal(IPAddr.new("1:2::3"), IPAddr.new("1:2::3").unmasked)
+    assert_equal(IPAddr.new("1:2::3"), IPAddr.new("1:2::3/16").unmasked)
+    assert_equal(IPAddr.new("1.2.3.4"), IPAddr.new(IPAddr.new("1.2.3.4").to_i, Socket::AF_INET).unmasked)
+    assert_equal(IPAddr.new("1.2.3.5"), IPAddr.new("1.2.3.4").succ.mask(8).unmasked)
+  end
 end


### PR DESCRIPTION
Prior to this commit there was no way to retrieve the unmasked address
for an `IPAddr`. For example, given the `IPAddr` below there is no
method or instance variable that would return `"1.2.3.4"`.

```rb
IPAddr.new("1.2.3.4/8")
```

This poses a problem for Rails in supporting the PostgreSQL inet type.
Rails uses `IPAddr` for both the cidr and inet types, but at the moment
cannot fully support the inet type, which "accepts values with nonzero
bits to the right of the netmask". This came up originally in
rails/rails#14857, and more recently in
rails/rails#40138. The change in this commit
would allow us to support the inet type without moving to another
library.

This commit holds onto the address before the mask is applied, in a new
instance variable `@unmasked_addr`. It then exposes this via
`unmasked`.

This was originally implemented back in
ruby/ruby#599, but it got stale and was
eventually closed. There are also a few differences with that PR:

- That PR set up the instance variable inside of `mask!`, which meant
  that the new method was broken in the case of an `IPAddr` with no
  mask.
- That PR introduced a method that returned a `to_s`-like value, whereas
  this one returns a new, unmasked IPAddr object.
- As a result of the above, this version doesn't need to change the
  signature of `to_s`
- This PR also sets @unmasked_addr within `set`, which covers a few
  additional edge cases with non-string arguments and with methods like
  `&` or `succ` that clone the IpAdrr and call `set`