### PR TITLE
Expose IPAddr::VERSION

### DIFF
--- a/ipaddr.gemspec
+++ b/ipaddr.gemspec
@@ -3,9 +3,13 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
+version = File.foreach(File.expand_path("ipaddr.rb", lib)).find do |line|
+  /^\s*VERSION\s*=\s*["'](.*)["']/ =~ line and break $1
+end
+
 Gem::Specification.new do |spec|
   spec.name          = "ipaddr"
-  spec.version       = "1.2.3"
+  spec.version       = version
   spec.authors       = ["Akinori MUSHA", "Hajimu UMEMOTO"]
   spec.email         = ["knu@idaemons.org", "ume@mahoroba.org"]
 

--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -40,6 +40,7 @@ require 'socket'
 #   p ipaddr3                   #=> #<IPAddr: IPv4:192.168.2.0/255.255.255.0>
 
 class IPAddr
+  VERSION = "1.2.3"
 
   # 32 bit mask for IPv4
   IN4MASK = 0xffffffff


### PR DESCRIPTION
An almost universal convention for gems is to expose Namespace::VERSION
which makes it much easier when debugging etc.

Similar to https://github.com/ruby/date/pull/42

cc @hsbt @mame 