### PR TITLE
Ipaddr#native must also coerce `@mask_addr`

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -509,6 +509,9 @@ class IPAddr
     @addr = addr
     if family[0]
       @family = family[0]
+      if @family == Socket::AF_INET
+        @mask_addr &= IN4MASK
+      end
     end
     return self
   end

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -360,6 +360,11 @@ class TC_Operator < Test::Unit::TestCase
 
   end
 
+  def test_native_coerce_mask_addr
+    assert_equal(IPAddr.new("0.0.0.2/255.255.255.255"), IPAddr.new("::2").native)
+    assert_equal(IPAddr.new("0.0.0.2/255.255.255.255").to_range, IPAddr.new("::2").native.to_range)
+  end
+
   def test_loopback?
     assert_equal(true,  IPAddr.new('127.0.0.1').loopback?)
     assert_equal(true,  IPAddr.new('127.127.1.1').loopback?)


### PR DESCRIPTION
Before it would be left as an IPv6 mask causing `to_range` to fail.

```
>> IPAddr.new("::2").native.to_range
/opt/rubies/3.0.3/lib/ruby/3.0.0/ipaddr.rb:479:in `set': invalid address (IPAddr::InvalidAddressError)
```

This bug seem quite old but it was hidden by https://github.com/ruby/ipaddr/pull/31

@hsbt @jeremyevans 