### PR TITLE
CI: Add Ruby 3.1 to matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ "3.0", 2.7, 2.6, 2.5, 2.4, 2.3, head, jruby-9.2, jruby-9.3, truffleruby-21.3.0 ]
+        ruby: [ 3.1, "3.0", 2.7, 2.6, 2.5, 2.4, 2.3, head, jruby-9.2, jruby-9.3, truffleruby-21.3.0 ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This PR extends the CI build matrix with Ruby 3.1.