### PR TITLE
Add IPAddr#wildcard_mask

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -464,6 +464,20 @@ class IPAddr
     _to_string(@mask_addr)
   end
 
+  # Returns the wildcard mask in string format e.g. 0.0.255.255
+  def wildcard_mask
+    case @family
+    when Socket::AF_INET
+      mask = IN4MASK ^ @mask_addr
+    when Socket::AF_INET6
+      mask = IN6MASK ^ @mask_addr
+    else
+      raise AddressFamilyError, "unsupported address family"
+    end
+
+    _to_string(mask)
+  end
+
   # Returns the IPv6 zone identifier, if present.
   # Raises InvalidAddressError if not an IPv6 address.
   def zone_id

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -244,6 +244,29 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(a.netmask, "255.255.255.0")
   end
 
+  def test_wildcard_mask
+    a = IPAddr.new("192.168.1.2/1")
+    assert_equal(a.wildcard_mask, "127.255.255.255")
+
+    a = IPAddr.new("192.168.1.2/8")
+    assert_equal(a.wildcard_mask, "0.255.255.255")
+
+    a = IPAddr.new("192.168.1.2/16")
+    assert_equal(a.wildcard_mask, "0.0.255.255")
+
+    a = IPAddr.new("192.168.1.2/24")
+    assert_equal(a.wildcard_mask, "0.0.0.255")
+
+    a = IPAddr.new("192.168.1.2/32")
+    assert_equal(a.wildcard_mask, "0.0.0.0")
+
+    a = IPAddr.new("3ffe:505:2::/48")
+    assert_equal(a.wildcard_mask, "0000:0000:0000:ffff:ffff:ffff:ffff:ffff")
+
+    a = IPAddr.new("3ffe:505:2::/128")
+    assert_equal(a.wildcard_mask, "0000:0000:0000:0000:0000:0000:0000:0000")
+  end
+
   def test_zone_id
     a = IPAddr.new("192.168.1.2")
     assert_raise(IPAddr::InvalidAddressError) { a.zone_id = '%ab0' }


### PR DESCRIPTION
Added to get an address of wildcard mask which is like a reverse subnet mask.
It uses to configure a network device for ACL or OSPF.

### Related links
- Wildcard Mask
  - https://en.wikipedia.org/wiki/Wildcard_mask
  - https://www.ciscopress.com/articles/article.asp?p=3089353&seqNum=5
