### PR TITLE
Fix truffleruby tests by upgrading truffleruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     name: build (${{ matrix.ruby }} / ${{ matrix.os }})
     strategy:
       matrix:
-        ruby: [ 3.1, "3.0", 2.7, 2.6, 2.5, 2.4, 2.3, head, jruby-9.2, jruby-9.3, truffleruby-21.3.0 ]
+        ruby: [ 3.1, "3.0", 2.7, 2.6, 2.5, 2.4, 2.3, head, jruby-9.2, jruby-9.3, truffleruby-22.3.0 ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The current combination of truffleruby 21.3.0 and ubuntu 22.04 does not exist as a published truffleruby binary. This previously worked because ubuntu-latest was 20.04, which does have a release published for truffleruby 21.3.0

See https://github.com/ruby/ruby-builder/releases/tag/toolcache for the full list of binaries