### PR TITLE
Prefer String#start_with? over Regexp.match

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -652,7 +652,7 @@ class IPAddr
     end
     octets.inject(0) { |i, s|
       (n = s.to_i) < 256 or raise InvalidAddressError, "invalid address: #{@addr}"
-      s.match(/\A0./) and raise InvalidAddressError, "zero-filled number in IPv4 address is ambiguous: #{@addr}"
+      (s != '0') && s.start_with?('0') and raise InvalidAddressError, "zero-filled number in IPv4 address is ambiguous: #{@addr}"
       i << 8 | n
     }
   end


### PR DESCRIPTION
Here's trivial performance improvement on IPv4 `in_addr`.

Benchmark result is as follows:
```
['0', '123', '03'].each do |s|
  p s
  Benchmark.ips do |x|
    x.report('old') { s.match(/\A0./) }
    x.report('new') { (s != '0') && s.start_with?('0') }
    x.compare!
  end
end


"0"
Warming up --------------------------------------
                 old   578.470k i/100ms
                 new     1.460M i/100ms
Calculating -------------------------------------
                 old      7.522M (± 0.7%) i/s -     38.179M in   5.076216s
                 new     24.614M (± 0.8%) i/s -    124.136M in   5.043628s

Comparison:
                 new: 24614178.4 i/s
                 old:  7521547.2 i/s - 3.27x  (± 0.00) slower

"123"
Warming up --------------------------------------
                 old   652.257k i/100ms
                 new     1.234M i/100ms
Calculating -------------------------------------
                 old      8.479M (± 0.6%) i/s -     42.397M in   5.000174s
                 new     18.665M (± 0.8%) i/s -     93.785M in   5.024798s

Comparison:
                 new: 18665473.8 i/s
                 old:  8479356.1 i/s - 2.20x  (± 0.00) slower

"03"
Warming up --------------------------------------
                 old   392.351k i/100ms
                 new     1.254M i/100ms
Calculating -------------------------------------
                 old      4.659M (± 1.3%) i/s -     23.541M in   5.053968s
                 new     19.023M (± 0.7%) i/s -     95.338M in   5.011941s

Comparison:
                 new: 19023166.8 i/s
                 old:  4658796.2 i/s - 4.08x  (± 0.00) slower
```