### PR TITLE
String#split seems to be faster than capturing digits with Regexp

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -52,7 +52,7 @@ class IPAddr
   # Regexp _internally_ used for parsing IPv4 address.
   RE_IPV4ADDRLIKE = %r{
     \A
-    (\d+) \. (\d+) \. (\d+) \. (\d+)
+    \d+ \. \d+ \. \d+ \. \d+
     \z
   }x
 
@@ -647,8 +647,8 @@ class IPAddr
     when Array
       octets = addr
     else
-      m = RE_IPV4ADDRLIKE.match(addr) or return nil
-      octets = m.captures
+      RE_IPV4ADDRLIKE.match?(addr) or return nil
+      octets = addr.split('.')
     end
     octets.inject(0) { |i, s|
       (n = s.to_i) < 256 or raise InvalidAddressError, "invalid address: #{@addr}"


### PR DESCRIPTION
Here's another tiny performance patch. The benchmark result below shows 1.23x speedup. Plus, the patched code should be more GC friendly.

```
addr = '192.168.1.99'
Benchmark.ips do |x|
  x.report('old') do
    m = RE_IPV4ADDRLIKE_OLD.match(addr) or return nil
    octets = m.captures
  end
  x.report('new') do
    RE_IPV4ADDRLIKE.match?(addr) or return nil
    octets = addr.split('.')
  end
  x.compare!
end

Warming up --------------------------------------
                 old   202.387k i/100ms
                 new   243.888k i/100ms
Calculating -------------------------------------
                 old      2.245M (± 2.1%) i/s -     11.334M in   5.049888s
                 new      2.764M (± 1.0%) i/s -     13.902M in   5.029862s

Comparison:
                 new:  2764111.4 i/s
                 old:  2245347.5 i/s - 1.23x  (± 0.00) slower
```