### PR TITLE
ntop: Measure address size in bytes

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -110,8 +110,13 @@ class IPAddr
 
   # Convert a network byte ordered string form of an IP address into
   # human readable form.
+  # It expects the string to be encoded in Encoding::ASCII_8BIT (BINARY).
   def self.ntop(addr)
-    case addr.size
+    if addr.is_a?(String) && addr.encoding != Encoding::BINARY
+      raise InvalidAddressError, "invalid encoding (given #{addr.encoding}, expected BINARY)"
+    end
+
+    case addr.bytesize
     when 4
       addr.unpack('C4').join('.')
     when 16

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -133,18 +133,37 @@ class TC_IPAddr < Test::Unit::TestCase
 
   def test_ntop
     # IPv4
-    assert_equal("192.168.1.1", IPAddr.ntop("\xC0\xA8\x01\x01"))
+    assert_equal("192.168.1.1", IPAddr.ntop("\xC0\xA8\x01\x01".b))
+    assert_equal("10.231.140.171", IPAddr.ntop("\x0A\xE7\x8C\xAB".b))
     # IPv6
     assert_equal("0000:0000:0000:0000:0000:0000:0000:0001",
-                 IPAddr.ntop("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01"))
+                 IPAddr.ntop("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01".b))
+    assert_equal("fe80:0000:0000:0000:f09f:9985:f09f:9986",
+                 IPAddr.ntop("\xFE\x80\x00\x00\x00\x00\x00\x00\xF0\x9F\x99\x85\xF0\x9F\x99\x86".b))
 
     # Invalid parameters
+    ## wrong length
     assert_raise(IPAddr::AddressFamilyError) {
+      IPAddr.ntop("192.168.1.1".b)
+    }
+    assert_raise(IPAddr::AddressFamilyError) {
+      IPAddr.ntop("\xC0\xA8\x01\xFF1".b)
+    }
+    ## UTF-8
+    assert_raise(IPAddr::InvalidAddressError) {
       IPAddr.ntop("192.168.1.1")
     }
-
-    assert_raise(IPAddr::AddressFamilyError) {
-      IPAddr.ntop("\xC0\xA8\x01\xFF1")
+    assert_raise(IPAddr::InvalidAddressError) {
+      IPAddr.ntop("\x0A\x0A\x0A\x0A")
+    }
+    assert_raise(IPAddr::InvalidAddressError) {
+      IPAddr.ntop("\x0A\xE7\x8C\xAB")
+    }
+    assert_raise(IPAddr::InvalidAddressError) {
+      IPAddr.ntop("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01")
+    }
+    assert_raise(IPAddr::InvalidAddressError) {
+      IPAddr.ntop("\xFE\x80\x00\x00\x00\x00\x00\x00\xF0\x9F\x99\x85\xF0\x9F\x99\x86")
     }
   end
 


### PR DESCRIPTION
`IPAddr.ntop` takes the binary representation of an IP address, whose length should be 4 or 16 *bytes* (not characters/codepoints).

This patch fixes the bug that `IPAddr.ntop` doesn't handle Strings in a multibyte encoding correctly.

Fixes: https://github.com/ruby/ipaddr/issues/56