### PR TITLE
Fix InvalidAddressError message

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -693,8 +693,8 @@ class IPAddr
       octets = addr.split('.')
     end
     octets.inject(0) { |i, s|
-      (n = s.to_i) < 256 or raise InvalidAddressError, "invalid address: #{@addr}"
-      (s != '0') && s.start_with?('0') and raise InvalidAddressError, "zero-filled number in IPv4 address is ambiguous: #{@addr}"
+      (n = s.to_i) < 256 or raise InvalidAddressError, "invalid address: #{addr}"
+      (s != '0') && s.start_with?('0') and raise InvalidAddressError, "zero-filled number in IPv4 address is ambiguous: #{addr}"
       i << 8 | n
     }
   end

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -557,4 +557,16 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(true, s.include?(a5))
     assert_equal(true, s.include?(a6))
   end
+
+  def test_raises_invalid_address_error_with_error_message
+    e = assert_raise(IPAddr::InvalidAddressError) do
+      IPAddr.new('192.168.0.1000')
+    end
+    assert_equal('invalid address: 192.168.0.1000', e.message)
+
+    e = assert_raise(IPAddr::InvalidAddressError) do
+      IPAddr.new('192.168.01.100')
+    end
+    assert_equal('zero-filled number in IPv4 address is ambiguous: 192.168.01.100', e.message)
+  end
 end


### PR DESCRIPTION
This is a pull request to fix Issue #60.
Fix to use the `addr` variable that exists instead of the `@addr` that does not exist.