### PR TITLE
Fix IPAddr#== returning true when compared with nil for 0.0.0.0 and ::

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -164,6 +164,10 @@ class IPAddr
 
   # Returns true if two ipaddrs are equal.
   def ==(other)
+    if other.nil?
+      return false
+    end
+
     other = coerce_other(other)
   rescue
     false

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -475,6 +475,8 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(false, @a != IPAddr.new("3ffe:505:2::"))
     assert_equal(false, @a == @inconvertible_range)
     assert_equal(false, @a == @inconvertible_string)
+    assert_equal(false, IPAddr.new("0.0.0.0") == nil)
+    assert_equal(false, IPAddr.new("::") == nil)
   end
 
   def test_compare


### PR DESCRIPTION
`IPAddr.new("0.0.0.0") == nil` and `nil == IPAddr.new("0.0.0.0")` return different results.

This Pull Request fixes `IPAddr.new("0.0.0.0") == nil` so that it returns false, consistent with the behavior of `IPAddr.new("0.0.0.0").nil?`.

- Fix #75

### Steps to reproduce
```ruby
# IPv4
IPAddr.new("0.0.0.0") == nil
#=> true # expected false

nil == IPAddr.new('0.0.0.0')
#=> false

IPAddr.new("0.0.0.0").nil?
#=> false

# IPv6
IPAddr.new("::") == nil
#=> true # expected false

nil == IPAddr.new("::")
#=> false

IPAddr.new("::").nil?
#=> false
```

### Expected behavior
`IPAddr.new("0.0.0.0") == nil` should return `false`, just like `IPAddr.new("0.0.0.0").nil?`.

### Actual behavior
`IPAddr.new("0.0.0.0") == nil` return `true`.

### System configuration
- IPAddr version: 1.2.8
- Ruby version: 4.0.1
  - `ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [arm64-darwin25]`

### Additional Information
This issue was discovered while investigating the following report:
- https://github.com/rails/rails/pull/51758#issuecomment-2311677430
