### PR TITLE
Add `IPAddr#to_json/as_json`

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -227,6 +227,22 @@ class IPAddr
     return str
   end
 
+  # Returns a string containing the IP address representation with prefix.
+  def as_json(*)
+    if ipv4? && prefix == 32
+      to_s
+    elsif ipv6? && prefix == 128
+      to_s
+    else
+      cidr
+    end
+  end
+
+  # Returns a json string containing the IP address representation.
+  def to_json(*)
+    format("\"%s\"", as_json)
+  end
+
   # Returns a string containing the IP address representation in
   # cidr notation
   def cidr

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -260,6 +260,20 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal("3ffe:505:2::1", IPAddr.new("3ffe:505:2::1").to_s)
   end
 
+  def test_as_json
+    assert_equal("192.168.1.2", IPAddr.new("192.168.1.2").as_json)
+    assert_equal("192.168.1.0/24", IPAddr.new("192.168.1.2/24").as_json)
+    assert_equal("2001:200:300::1", IPAddr.new("2001:200:300::1").as_json)
+    assert_equal("2001:200:300::/48", IPAddr.new("2001:200:300::/48").as_json)
+  end
+
+  def test_to_json
+    assert_equal("\"192.168.1.2\"", IPAddr.new("192.168.1.2").to_json)
+    assert_equal("\"192.168.1.0/24\"", IPAddr.new("192.168.1.2/24").to_json)
+    assert_equal("\"2001:200:300::1\"", IPAddr.new("2001:200:300::1").to_json)
+    assert_equal("\"2001:200:300::/48\"", IPAddr.new("2001:200:300::/48").to_json)
+  end
+
   def test_netmask
     a = IPAddr.new("192.168.1.2/8")
     assert_equal(a.netmask, "255.0.0.0")


### PR DESCRIPTION
Add `to_json/as_json` methods to get json format string.

When use json gem, `IPAddr#to_json` remove prefix address with CIDR.
Although json gem have no paln to support for IPAddr class.
https://github.com/ruby/json/issues/503

### Actual behavior

```ruby
require 'ipaddr'
require 'json'

IPAddr.new('172.16.0.0/24').to_json #=> "\"172.16.0.0\""
```

### This PR behavior
`IPAddr#to_json` method return json format address wit prefix without json gem.
(When to require json gem, it have same behavior.)

```ruby
require 'ipaddr'

IPAddr.new('172.16.0.0/24').to_json #=> "\"172.16.0.0/24\""

IPAddr.new('172.16.0.1').to_json #=> "\"172.16.0.1\""
```

