### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/ipaddr.gemspec
+++ b/ipaddr.gemspec
@@ -32,5 +32,5 @@ Both IPv4 and IPv6 are supported.
   spec.files         = ["LICENSE.txt", "README.md", "ipaddr.gemspec", "lib/ipaddr.rb"]
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.4"
 end


### PR DESCRIPTION
It fix incorrect required_ruby_version.
Fix #78

It seems it has made the consensus about drop support ruby 2.3.
https://github.com/ruby/ipaddr/pull/50#issuecomment-1376670397

FYI: CI already supports Ruby 2.4+ (#66)