### PR TITLE
Fix IPAddr equality to compare network masks

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -167,7 +167,7 @@ class IPAddr
   rescue
     false
   else
-    @family == other.family && @addr == other.to_i
+    @family == other.family && @addr == other.to_i && @mask_addr == other.instance_variable_get(:@mask_addr)
   end
 
   # Returns a new ipaddr built by masking IP address with the given

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -440,12 +440,16 @@ class TC_Operator < Test::Unit::TestCase
   end
 
   def test_equal
-    assert_equal(true, @a == IPAddr.new("3FFE:505:2::"))
-    assert_equal(true, @a == IPAddr.new("3ffe:0505:0002::"))
-    assert_equal(true, @a == IPAddr.new("3ffe:0505:0002:0:0:0:0:0"))
-    assert_equal(false, @a == IPAddr.new("3ffe:505:3::"))
+    assert_equal(true, @a == IPAddr.new("3FFE:0505:2::/48"))
+    assert_equal(true, @a == IPAddr.new("3ffe:0505:0002::/48"))
+    assert_equal(true, @a == IPAddr.new("3ffe:0505:0002:0:0:0:0:0/48"))
+    assert_equal(false, @a == IPAddr.new("3FFE:505:2::"))
+    assert_equal(false, @a == IPAddr.new("3ffe:0505:0002::"))
+    assert_equal(false, @a == IPAddr.new("3ffe:0505:0002:0:0:0:0:0"))
+    assert_equal(false, @a == IPAddr.new("3ffe:0505:2::1/128"))
+    assert_equal(false, @a == IPAddr.new("3ffe:0505:0002:0:0:0:0:1/128"))
     assert_equal(true, @a != IPAddr.new("3ffe:505:3::"))
-    assert_equal(false, @a != IPAddr.new("3ffe:505:2::"))
+    assert_equal(true, @a != IPAddr.new("3ffe:505:2::"))
     assert_equal(false, @a == @inconvertible_range)
     assert_equal(false, @a == @inconvertible_string)
   end


### PR DESCRIPTION
## Why Address Mask is Essential for IPAddr Equality

In networking, an IP address without a prefix/netmask is fundamentally incomplete. 

Two IP addresses should only be compared using the address, mask, and version because the mask determines which bits identify the network and which bits identify the host.

Without the mask, two addresses like `2001:db8::1/32` and `2001:db8::1/48` may appear identical, but they represent different scopes—different network ranges, not a full subnet versus a single host.

Comparing only the address and version ignores this important context, leading to inaccurate network identities.
This is relevant for access control and routing.

**The Problem:**
```ruby
# Before this fix:
IPAddr.new("2001:db8::1/48") == IPAddr.new("2001:db8::1/32")  # => true (wrong!)
```

These represent entirely different networks:
- `2001:db8::1/48` is a network with **2^80** usable host addresses  
- `2001:db8::1/32` is a network with **2^96** usable host addresses

**The Solution:**
By including `@mask_addr` in equality, we ensure that two `IPAddr` objects are equal only when they represent the same network scope, not just the same base address.

**IPv6 Example:**
```ruby
a = IPAddr.new("2001:db8::1/32")    # Regional Internet Registry allocation
b = IPAddr.new("2001:db8::1/48")    # Single organization assignment

a == b  # Now correctly returns false
```

This change fixes the issue by including `@mask_addr` in the equality check. As a result, equality now reflects both the address value and the applied network mask, which better matches user expectations and common networking semantics.

The test suite has been updated to ensure comparisons now account for prefix length differences.

This aligns with RFC 4291's definition that IPv6 addresses are meaningless without their prefix length context, and matches the behavior network engineers expect when comparing network identities, making `IPAddr#==` semantically correct according to networking standards rather than just comparing raw integer values.
