### PR TITLE
Fix `#ipv4_compat` returning invalid prefix

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -381,7 +381,9 @@ class IPAddr
     if !ipv4?
       raise InvalidAddressError, "not an IPv4 address: #{@addr}"
     end
-    return self.clone.set(@addr, Socket::AF_INET6)
+    clone = self.clone.set(@addr, Socket::AF_INET6)
+    clone.instance_variable_set(:@mask_addr, @mask_addr | 0xffffffffffffffffffffffff00000000)
+    clone
   end
 
   # Returns a new ipaddr built by converting the IPv6 address into a

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -196,6 +196,13 @@ class TC_IPAddr < Test::Unit::TestCase
     }
     assert_equal("::192.168.1.2", b.to_s)
     assert_equal(Socket::AF_INET6, b.family)
+    assert_equal(128, b.prefix)
+
+    a = IPAddr.new("192.168.0.0/16")
+    b = a.ipv4_compat
+    assert_equal("::192.168.0.0", b.to_s)
+    assert_equal(Socket::AF_INET6, b.family)
+    assert_equal(112, b.prefix)
   end
 
   def test_ipv4_mapped


### PR DESCRIPTION
### Background
IPv4-Compatible IPv6 Addresses are within the `::/96` range, so their prefix must be at least 96.  
However, the current implementation of `#ipv4_compat` always returns a prefix of 0, which is incorrect.  
https://www.rfc-editor.org/rfc/rfc4291.html#section-2.5.5.1

- Fix #27
- Close #18

### Details
This Pull Request fixes the `#ipv4_compat` method so that the returned address has the correct prefix (>= 96).

### Expected behavior
```ruby
ip4 = IPAddr.new('192.168.1.1').ipv4_compat
=> #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:c0a8:0101/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>
ip4.to_s
=> "::192.168.1.1"
ip4.prefix
=> 128

ip4 = IPAddr.new('192.168.0.0/16').ipv4_compat
=> #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:c0a8:0000/ffff:ffff:ffff:ffff:ffff:ffff:ffff:0000>
ip4.to_s
=> "::192.168.0.0"
ip4.prefix
112
```

### Actual behavior
```ruby
ip4 = IPAddr.new('192.168.1.1').ipv4_compat
=> #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:c0a8:0101/0000:0000:0000:0000:0000:0000:ffff:ffff>
ip4.to_s
=> "::192.168.1.1"
ip4.prefix
=> 0

ip4 = IPAddr.new('192.168.0.0/16').ipv4_compat
=> #<IPAddr: IPv6:0000:0000:0000:0000:0000:0000:c0a8:0000/0000:0000:0000:0000:0000:0000:ffff:0000>
ip4.to_s
=> "::192.168.0.0"
ip4.prefix
=> 0
```

### Additional Information
The `#ipv4_compat` method is obsolete because IPv4-Compatible IPv6 Addresses were deprecated in RFC 4291.
Therefore, I believe fixing the returned prefix will not introduce compatibility issues.
- commit: https://github.com/ruby/ipaddr/commit/0980b006540bca83e6ca21e74e6e211b9612c311
- https://www.rfc-editor.org/rfc/rfc4291.html#section-2.5.5.1

> `#ipv4_compat` still returns an inconsistent mask. As it's been deprecated (in IETF and in this library), I don't think we need to maintain it. However, this violation in object invariant ("the netmask must be consecutive 1s followed by consecutive 0s") may cause other problems and I'd propose fixing it like `#ipv4_mapped` if we cannot remove `#ipv4_compat` now.
- https://github.com/ruby/ipaddr/issues/27#issuecomment-1829067747

