### PR TITLE
Remove warning by asserting its presence

### DIFF
--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -199,7 +199,9 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(128, b.prefix)
 
     a = IPAddr.new("192.168.0.0/16")
-    b = a.ipv4_compat
+    assert_warning(/obsolete/) {
+      b = a.ipv4_compat
+    }
     assert_equal("::192.168.0.0", b.to_s)
     assert_equal(Socket::AF_INET6, b.family)
     assert_equal(112, b.prefix)


### PR DESCRIPTION
	$ rake test >/dev/null
	/tmp/test/test_ipaddr.rb:202: warning: IPAddr#ipv4_compat is obsolete

This shows up in Ruby's CI too.