### PR TITLE
Follow-up fix for InvalidAddressError messages

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -368,7 +368,7 @@ class IPAddr
   # into an IPv4-mapped IPv6 address.
   def ipv4_mapped
     if !ipv4?
-      raise InvalidAddressError, "not an IPv4 address: #{@addr}"
+      raise InvalidAddressError, "not an IPv4 address: #{to_s}"
     end
     clone = self.clone.set(@addr | 0xffff00000000, Socket::AF_INET6)
     clone.instance_variable_set(:@mask_addr, @mask_addr | 0xffffffffffffffffffffffff00000000)
@@ -380,7 +380,7 @@ class IPAddr
   def ipv4_compat
     warn "IPAddr\##{__callee__} is obsolete", uplevel: 1 if $VERBOSE
     if !ipv4?
-      raise InvalidAddressError, "not an IPv4 address: #{@addr}"
+      raise InvalidAddressError, "not an IPv4 address: #{to_s}"
     end
     clone = self.clone.set(@addr, Socket::AF_INET6)
     clone.instance_variable_set(:@mask_addr, @mask_addr | 0xffffffffffffffffffffffff00000000)
@@ -413,7 +413,7 @@ class IPAddr
   # Returns a string for DNS reverse lookup compatible with RFC3172.
   def ip6_arpa
     if !ipv6?
-      raise InvalidAddressError, "not an IPv6 address: #{@addr}"
+      raise InvalidAddressError, "not an IPv6 address: #{to_s}"
     end
     return _reverse + ".ip6.arpa"
   end
@@ -421,7 +421,7 @@ class IPAddr
   # Returns a string for DNS reverse lookup compatible with RFC1886.
   def ip6_int
     if !ipv6?
-      raise InvalidAddressError, "not an IPv6 address: #{@addr}"
+      raise InvalidAddressError, "not an IPv6 address: #{to_s}"
     end
     return _reverse + ".ip6.int"
   end
@@ -743,19 +743,19 @@ class IPAddr
       right = ''
     when RE_IPV6ADDRLIKE_COMPRESSED
       if $4
-        left.count(':') <= 6 or raise InvalidAddressError, "invalid address: #{@addr}"
+        left.count(':') <= 6 or raise InvalidAddressError, "invalid address: #{left}"
         addr = in_addr($~[4,4])
         left = $1
         right = $3 + '0:0'
       else
         left.count(':') <= ($1.empty? || $2.empty? ? 8 : 7) or
-          raise InvalidAddressError, "invalid address: #{@addr}"
+          raise InvalidAddressError, "invalid address: #{left}"
         left = $1
         right = $2
         addr = 0
       end
     else
-      raise InvalidAddressError, "invalid address: #{@addr}"
+      raise InvalidAddressError, "invalid address: #{left}"
     end
     l = left.split(':')
     r = right.split(':')

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -207,6 +207,15 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(112, b.prefix)
   end
 
+  def test_ipv4_compat_with_error_message
+    e = assert_raise(IPAddr::InvalidAddressError) do
+      assert_warning(/obsolete/) {
+        IPAddr.new('2001:db8::').ipv4_compat
+      }
+    end
+    assert_equal('not an IPv4 address: 2001:db8::', e.message)
+  end
+
   def test_ipv4_mapped
     a = IPAddr.new("::ffff:192.168.1.2")
     assert_equal("::ffff:192.168.1.2", a.to_s)
@@ -224,6 +233,13 @@ class TC_IPAddr < Test::Unit::TestCase
     assert_equal(Socket::AF_INET6, b.family)
   end
 
+  def test_ipv4_mapped_with_error_message
+    e = assert_raise(IPAddr::InvalidAddressError) do
+      IPAddr.new('2001:db8::').ipv4_mapped
+    end
+    assert_equal('not an IPv4 address: 2001:db8::', e.message)
+  end
+
   def test_reverse
     assert_equal("f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa", IPAddr.new("3ffe:505:2::f").reverse)
     assert_equal("1.2.168.192.in-addr.arpa", IPAddr.new("192.168.2.1").reverse)
@@ -231,16 +247,18 @@ class TC_IPAddr < Test::Unit::TestCase
 
   def test_ip6_arpa
     assert_equal("f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0.5.0.5.0.e.f.f.3.ip6.arpa", IPAddr.new("3ffe:505:2::f").ip6_arpa)
-    assert_raise(IPAddr::InvalidAddressError) {
+    e = assert_raise(IPAddr::InvalidAddressError) {
       IPAddr.new("192.168.2.1").ip6_arpa
     }
+    assert_equal('not an IPv6 address: 192.168.2.1', e.message)
   end
 
   def test_ip6_int
     assert_equal("f.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.2.0.0.0.5.0.5.0.e.f.f.3.ip6.int", IPAddr.new("3ffe:505:2::f").ip6_int)
-    assert_raise(IPAddr::InvalidAddressError) {
+    e = assert_raise(IPAddr::InvalidAddressError) {
       IPAddr.new("192.168.2.1").ip6_int
     }
+    assert_equal('not an IPv6 address: 192.168.2.1', e.message)
   end
 
   def test_prefix_writer
@@ -631,5 +649,10 @@ class TC_Operator < Test::Unit::TestCase
       IPAddr.new('192.168.01.100')
     end
     assert_equal('zero-filled number in IPv4 address is ambiguous: 192.168.01.100', e.message)
+
+    e = assert_raise(IPAddr::InvalidAddressError) do
+      IPAddr.new('INVALID')
+    end
+    assert_equal('invalid address: INVALID', e.message)
   end
 end


### PR DESCRIPTION
### Background
In the following Pull Request, an issue was fixed where the error message for `InvalidAddressError` did not include the invalid IP address:
- #70
- Fix #60

This Pull Request fixes additional cases where the invalid IP address is still not shown in the `InvalidAddressError` message, as well as cases where the error message shows a numeric value instead of an address format.

### Details
#### Invalid address is not shown
When an invalid non-IPv4 address value is passed to `IPAddr#new`, `@addr` is not set. As a result, the error message ends up missing the invalid address.
In this case, the argument (`left`) passed to the `in6_addr` method, where the exception is raised, is now included in the error message.

For example:
```ruby
IPAddr.new("INVALID")
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:758:in 'IPAddr#in6_addr': invalid address:  (IPAddr::InvalidAddressError)
```

#### Numeric value instead of an address representation
In some cases, the address shown in the error message is a numeric value such as `42540766411282592856903984951653826560` instead of a human-readable address format like `2001:db8::`.
This Pull Request updates the error messages to display the address in a human-readable format.

For example:
```ruby
IPAddr.new('2001:db8::').ipv4_mapped
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:371:in 'IPAddr#ipv4_mapped': not an IPv4 address: 42540766411282592856903984951653826560 (IPAddr::InvalidAddressError)
```

The following methods are updated to improve their error messages:
- `#ipv4_mapped`
- `#ipv4_compat`
- `#ip6_arpa`
- `#ip6_int`


### Expected behavior

```ruby
# IPAddr#new with invalid string
IPAddr.new("INVALID")
/Users/taketo/path/ipaddr/lib/ipaddr.rb:758:in 'IPAddr#in6_addr': invalid address: INVALID (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "invalid address: #{left}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /Users/taketo/path/ipaddr/lib/ipaddr.rb:693:in 'IPAddr#initialize'
...

# IPAddr#ipv4_mapped with IPv6 address
IPAddr.new('2001:db8::').ipv4_mapped
/Users/taketo/path/ipaddr/lib/ipaddr.rb:371:in 'IPAddr#ipv4_mapped': not an IPv4 address: 2001:db8:: (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv4 address: #{to_s}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# IPAddr#ipv4_compat with IPv6 address
IPAddr.new('2001:db8::').ipv4_compat
/Users/taketo/path/ipaddr/lib/ipaddr.rb:383:in 'IPAddr#ipv4_compat': not an IPv4 address: 2001:db8:: (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv4 address: #{to_s}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# IPAddr#ip6_arpa with IPv4 address
IPAddr.new("192.168.2.1").ip6_arpa
/Users/taketo/path/ipaddr/lib/ipaddr.rb:416:in 'IPAddr#ip6_arpa': not an IPv6 address: 192.168.2.1 (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv6 address: #{to_s}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# IPAddr#ip6_int with IPv4 address
IPAddr.new("192.168.2.1").ip6_int
/Users/taketo/path/ipaddr/lib/ipaddr.rb:424:in 'IPAddr#ip6_int': not an IPv6 address: 192.168.2.1 (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv6 address: #{to_s}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

### Actual behavior
```sh
$ ruby -v
ruby 4.0.0dev (2025-12-17T12:11:27Z master aee4b24829) +PRISM [arm64-darwin25]
```
```ruby
IPAddr::VERSION
=> "1.2.8"

# IPAddr#new with invalid string
IPAddr.new("INVALID")
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:758:in 'IPAddr#in6_addr': invalid address:  (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "invalid address: #{@addr}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	from /Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:693:in 'IPAddr#initialize'
...

# IPAddr#ipv4_mapped with IPv6 address
IPAddr.new('2001:db8::').ipv4_mapped
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:371:in 'IPAddr#ipv4_mapped': not an IPv4 address: 42540766411282592856903984951653826560 (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv4 address: #{@addr}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# IPAddr#ipv4_compat with IPv6 address
IPAddr.new('2001:db8::').ipv4_compat
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:383:in 'IPAddr#ipv4_compat': not an IPv4 address: 42540766411282592856903984951653826560 (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv4 address: #{@addr}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# IPAddr#ip6_arpa with IPv4 address
IPAddr.new("192.168.2.1").ip6_arpa
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:416:in 'IPAddr#ip6_arpa': not an IPv6 address: 3232236033 (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv6 address: #{@addr}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

# IPAddr#ip6_int with IPv4 address
IPAddr.new("192.168.2.1").ip6_int
/Users/taketo/.rbenv/versions/4.0-dev/lib/ruby/4.0.0+1/ipaddr.rb:424:in 'IPAddr#ip6_int': not an IPv6 address: 3232236033 (IPAddr::InvalidAddressError)

      raise InvalidAddressError, "not an IPv6 address: #{@addr}"
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
