### PR TITLE
Fix IPAddr#private?, #link_local? and #loopback? incorrectly matching public IPv6 addresses as IPv4-mapped

### DIFF
--- a/lib/ipaddr.rb
+++ b/lib/ipaddr.rb
@@ -293,7 +293,7 @@ class IPAddr
       @addr & 0xff000000 == 0x7f000000 # 127.0.0.1/8
     when Socket::AF_INET6
       @addr == 1 || # ::1
-        (@addr & 0xffff_0000_0000 == 0xffff_0000_0000 && (
+        (@addr >> 32 == 0xffff && (
           @addr & 0xff000000 == 0x7f000000 # ::ffff:127.0.0.1/8
         ))
     else
@@ -314,10 +314,10 @@ class IPAddr
         @addr & 0xffff0000 == 0xc0a80000     # 192.168.0.0/16
     when Socket::AF_INET6
       @addr & 0xfe00_0000_0000_0000_0000_0000_0000_0000 == 0xfc00_0000_0000_0000_0000_0000_0000_0000 ||
-        (@addr & 0xffff_0000_0000 == 0xffff_0000_0000 && (
+        (@addr >> 32 == 0xffff && (
           @addr & 0xff000000 == 0x0a000000 ||  # ::ffff:10.0.0.0/8
-          @addr & 0xfff00000 == 0xac100000 ||  # ::ffff::172.16.0.0/12
-          @addr & 0xffff0000 == 0xc0a80000     # ::ffff::192.168.0.0/16
+          @addr & 0xfff00000 == 0xac100000 ||  # ::ffff:172.16.0.0/12
+          @addr & 0xffff0000 == 0xc0a80000     # ::ffff:192.168.0.0/16
         ))
     else
       raise AddressFamilyError, "unsupported address family"
@@ -335,7 +335,7 @@ class IPAddr
       @addr & 0xffff0000 == 0xa9fe0000 # 169.254.0.0/16
     when Socket::AF_INET6
       @addr & 0xffc0_0000_0000_0000_0000_0000_0000_0000 == 0xfe80_0000_0000_0000_0000_0000_0000_0000 || # fe80::/10
-        (@addr & 0xffff_0000_0000 == 0xffff_0000_0000 && (
+        (@addr >> 32 == 0xffff && (
           @addr & 0xffff0000 == 0xa9fe0000 # ::ffff:169.254.0.0/16
         ))
     else

--- a/test/test_ipaddr.rb
+++ b/test/test_ipaddr.rb
@@ -533,6 +533,9 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(false, IPAddr.new('::ffff:0.0.0.0').loopback?)
     assert_equal(false, IPAddr.new('::ffff:192.168.2.0').loopback?)
     assert_equal(false, IPAddr.new('::ffff:255.0.0.0').loopback?)
+
+    # Global unicast addresses with 0xffff in group 5 must not be mistaken for ::ffff:127.x.x.x
+    assert_equal(false, IPAddr.new('2001:db8:1:1:0:ffff:7f00:1').loopback?)
   end
 
   def test_private?
@@ -583,6 +586,10 @@ class TC_Operator < Test::Unit::TestCase
     assert_equal(false, IPAddr.new('::ffff:192.169.0.0').private?)
 
     assert_equal(false, IPAddr.new('::ffff:169.254.0.1').private?)
+
+    # Global unicast addresses with 0xffff in group 5 must not be mistaken for ::ffff:10/172.16/192.168.x
+    assert_equal(false, IPAddr.new('2001:718:1404:c8:0:ffff:ac19:c80e').private?)
+    assert_equal(false, IPAddr.new('2001:db8:1:1:0:ffff:c0a8:1').private?)
   end
 
   def test_link_local?
@@ -609,6 +616,9 @@ class TC_Operator < Test::Unit::TestCase
 
     assert_equal(true,  IPAddr.new('::ffff:169.254.1.1').link_local?)
     assert_equal(true,  IPAddr.new('::ffff:169.254.254.255').link_local?)
+
+    # Global unicast addresses with 0xffff in group 5 must not be mistaken for ::ffff:169.254.x.x
+    assert_equal(false, IPAddr.new('2001:db8:1:1:0:ffff:a9fe:101').link_local?)
   end
 
   def test_hash


### PR DESCRIPTION
## Summary

`IPAddr#private?`, `#loopback?`, and `#link_local?` all use this pattern to detect whether an IPv6 address is an IPv4-mapped private/loopback/link-local address:

```ruby
@addr & 0xffff_0000_0000 == 0xffff_0000_0000
```

This mask only tests bits 32–47 of the 128-bit address. It does **not** verify that the upper 80 bits are zero, which is required for a true IPv4-mapped address (`::ffff:x.x.x.x` = `0000:0000:0000:0000:0000:ffff:x:x`).

Any native IPv6 global unicast address that has `0xffff` in its 5th 16-bit group will incorrectly match. For example:

```ruby
IPAddr.new("2001:718:1404:c8:0:ffff:ac19:c80e").private?   # => true  (wrong)
IPAddr.new("2001:db8:1:1:0:ffff:a9fe:101").link_local?     # => true  (wrong)
IPAddr.new("2001:db8:1:1:0:ffff:7f00:1").loopback?         # => true  (wrong)
```

These are legitimate globally routable addresses. `ipv4_mapped?` correctly returns `false` for all of them (it's implementation is more precise)

## Fix

Replace the loose mask with a right-shift that validates all 96 upper bits at once, exactly the same test that `ipv4_mapped?` is doing:

```ruby
# Before — only checks bits 32-47
@addr & 0xffff_0000_0000 == 0xffff_0000_0000

# After — checks that bits 32-127 are exactly ::ffff: (0000:0000:0000:0000:0000:ffff:)
@addr >> 32 == 0xffff
```

`@addr >> 32 == 0xffff` requires the upper 96 bits to equal `0x0000_0000_0000_0000_0000_ffff`, which is the precise definition of the IPv4-mapped prefix.

## Real-world impact

This issue was brought to my attention by a savvy user of [my service](https://updown.io) whose monitored site has AAAA record `2001:718:1404:c8:0:ffff:ac19:c80e` (a perfectly valid and working global unicast IPv6). My SSRF protection, which relied on `IPAddr#private?`, started incorrectly rejecting it as a private address.

Do not hesitate if you need any other tweaks, tests or explanation.
Thanks !